### PR TITLE
Game logic changes and corrections

### DIFF
--- a/docs/unmerged/game_logic.md
+++ b/docs/unmerged/game_logic.md
@@ -69,7 +69,7 @@ player.accountID and player.accountName suddenly became server side only. It is 
 
 ```krunkscript
 player.position.x = 10;        # num set x pos
-player.rotation.x;             # num XZ plane rotation in rad (read-only)
+player.rotation.x;             # num XZ plane rotation in radians (read-only)
 player.velocity.x = 0.1;       # num set x velocity
 
 player.sid;                    # num short id
@@ -213,7 +213,7 @@ player.disableDefault("jump");
 # Inputs get disabled within the "onPlayerUpdate" hook, which has the following controlls:
 inputs.mouseY;          #num mouse y direction
 inputs.mouseX;          #num mouse x direction
-inputs.movDir;          #num W, A, S, D inputs converted to direction in rad
+inputs.movDir;          #num W, A, S, D inputs converted to direction in radians
 
 inputs.lMouse;          #bool left mouse
 inputs.rMouse;          #bool right mouse

--- a/docs/unmerged/game_logic.md
+++ b/docs/unmerged/game_logic.md
@@ -69,7 +69,7 @@ player.accountID and player.accountName suddenly became server side only. It is 
 
 ```krunkscript
 player.position.x = 10;        # num set x pos
-player.rotation.x = 0.3;       # num set x direction
+player.rotation.x;             # num XZ plane rotation in rad (read-only)
 player.velocity.x = 0.1;       # num set x velocity
 
 player.sid;                    # num short id
@@ -82,7 +82,7 @@ player.health = 10;            # num health
 player.score = 5;              # num score (server-side)
 player.visible = false;        # bool visible
 player.team;                   # num team (read-only)
-player.ammo                    # num ammo count (read-only)
+player.ammo;                    # num ammo count (read-only)
 
 player.classIndex;             # num returns class ID
 player.loadoutIndex;           # num weapon slot ID
@@ -213,7 +213,7 @@ player.disableDefault("jump");
 # Inputs get disabled within the "onPlayerUpdate" hook, which has the following controlls:
 inputs.mouseY;          #num mouse y direction
 inputs.mouseX;          #num mouse x direction
-inputs.movDir;          #num W, A, S, D inputs converted to direction
+inputs.movDir;          #num W, A, S, D inputs converted to direction in rad
 
 inputs.lMouse;          #bool left mouse
 inputs.rMouse;          #bool right mouse


### PR DESCRIPTION
Added ; to player.ammo
Added "in rad" to inputs.movDir
When attempting to set player.rotation it instantly resets the rotation to prev rotation, believe its a bug as last time I checked it works when we switch movement type, but for now changed it to read-only